### PR TITLE
Added try clause around os.chmod() call

### DIFF
--- a/pyflow/src/pyflow.py
+++ b/pyflow/src/pyflow.py
@@ -777,8 +777,10 @@ if __name__ == '__main__' :
 """ % (taskInfoFileName, taskStateFileName, workflowClassName))
 
     dsfp.close()
-    os.chmod(taskDotScriptFile, 0755)
-
+    try:
+        os.chmod(taskDotScriptFile, 0755)
+    except OSError:
+        sys.stderr.write("OSError in trying to change permissions for taskDotScriptFile")
 
 
 ################################################################


### PR DESCRIPTION
Wrapped the os.chmod() function in a try clause. Current version comes to a halt when system restricts the changing of permissions. 